### PR TITLE
Make distkv optional

### DIFF
--- a/distmqtt/distkv_broker.py
+++ b/distmqtt/distkv_broker.py
@@ -7,9 +7,12 @@ from typing import Optional
 
 from distmqtt.broker import Broker
 
-from distkv.client import client_scope as distkv_client_scope
-from distkv.util import PathLongener, NotGiven
-from distkv.errors import ErrorRoot
+try:
+    from distkv.client import client_scope as distkv_client_scope
+    from distkv.util import PathLongener, NotGiven
+    from distkv.errors import ErrorRoot
+except ImportError:
+    pass
 
 
 class DistKVbroker(Broker):

--- a/distmqtt/test.py
+++ b/distmqtt/test.py
@@ -7,20 +7,25 @@ import anyio
 from contextlib import asynccontextmanager
 from functools import partial
 
-from distkv.server import Server as _Server
-from distkv.client import open_client
 from distmqtt.broker import create_broker
 
+try:
+    from distkv.server import Server as _Server
+    from distkv.client import open_client
+except ImportError:
+    _Server = None
 
-class Server(_Server):
-    @asynccontextmanager
-    async def test_client(self):
-        """
-        An async context manager that returns a client that's connected to
-        this server.
-        """
-        async with open_client(connect=dict(host="127.0.0.1", port=self.distkv_port)) as client:
-            yield client
+if _Server:
+
+    class Server(_Server):
+        @asynccontextmanager
+        async def test_client(self):
+            """
+            An async context manager that returns a client that's connected to
+            this server.
+            """
+            async with open_client(connect=dict(host="127.0.0.1", port=self.distkv_port)) as client:
+                yield client
 
 
 @asynccontextmanager

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,12 @@ setup(
         "pyyaml",
         "anyio >= 1.3",
         "attrs >= 19",
-        "distkv >= 0.30.5",
         "simplejson",
+        "msgpack",
     ],
+    extras_require={
+        "distkv": ["distkv >= 0.30.5"],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -2,7 +2,11 @@ import pytest
 import trio  # noqa: F401
 
 from distmqtt.test import test_server, test_client
-from distkv.util import P
+
+try:
+    from distkv.util import P
+except ImportError:
+    pytestmark = pytest.mark.skip
 
 
 @pytest.mark.trio


### PR DESCRIPTION
Fixes #2 

A bit more than the three lines you estimated. :P

I did notice that the tests in `test_client_distkv.py` were already failing. Though I made no attempt to fix those, that whole file does get skipped if `distkv` is *not* available, leading to a successful test run.

Side note: AFAICT, distmqtt works under Python 3.8, but I did not take the liberty of adding that classifier in `setup.py`.