### PR TITLE
Fix double-TLS-negotiation

### DIFF
--- a/distmqtt/client.py
+++ b/distmqtt/client.py
@@ -655,8 +655,6 @@ class MQTTClient:
                 conn = await anyio.connect_tcp(
                     self.session.remote_address, self.session.remote_port, **kwargs
                 )
-                if secure:
-                    await conn.start_tls()
                 adapter = StreamAdapter(conn)
             elif scheme in ("ws", "wss"):
                 if kwargs.pop("autostart_tls", False):


### PR DESCRIPTION
It was already handled via kwargs to `connect_tcp()`.

Fixes: #5