### PR TITLE
Fix: connect() got unexpected keyword argument

### DIFF
--- a/distmqtt/client.py
+++ b/distmqtt/client.py
@@ -158,7 +158,9 @@ async def open_mqttclient(uri=None, client_id=None, config={}, codec=None):
             if uri is not None:
                 config["uri"] = uri
             if "uri" in config:
-                await C.connect(**config)
+                known_keys = ("uri", "cleansession", "cafile", "capath", "cadata", "extra_headers")
+                kwargs = {k: v for k, v in config.items() if k in known_keys}
+                await C.connect(**kwargs)
             yield C
         finally:
             async with anyio.fail_after(2, shield=True):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,6 +66,18 @@ class MQTTClientTest(unittest.TestCase):
 
         anyio_run(test_coro)
 
+    def test_uri_supplied_early(self):
+        config = {'auto_reconnect': False}
+
+        async def test_coro():
+            async with open_mqttclient("mqtt://test.mosquitto.org/", config=config) as client:
+                self.assertIsNotNone(client.session)
+
+        try:
+            anyio_run(test_coro)
+        except ConnectException:
+            log.error("Broken by server")
+
     def test_connect_ws(self):
         async def test_coro():
             async with create_broker(broker_config, plugin_namespace="distmqtt.test.plugins"):


### PR DESCRIPTION
Without this fix, when passing URI and a config to `open_mqttclient`, we would get this error:

```
TypeError: connect() got an unexpected keyword argument 'auto_reconnect'
```