### PR TITLE
fix reconnect, use ConnectionError ...

### DIFF
--- a/distmqtt/client.py
+++ b/distmqtt/client.py
@@ -246,8 +246,8 @@ class MQTTClient:
 
         try:
             return await self._do_connect()
-        except SyntaxError as be:
-            self.logger.warning("Connection failed: %r", be)
+        except ConnectionError as e:
+            self.logger.warning("Connection failed: %r", e)
             auto_reconnect = self.config.get("auto_reconnect", False)
             if not auto_reconnect:
                 raise
@@ -315,7 +315,7 @@ class MQTTClient:
             try:
                 self.logger.debug("Reconnect attempt %d ...", nb_attempt)
                 return await self._do_connect()
-            except SyntaxError as e:  # no you can't reconnect on every exception
+            except ConnectionError as e:
                 self.logger.warning("Reconnection attempt failed: %r", e)
                 if reconnect_retries >= 0 and nb_attempt > reconnect_retries:
                     self.logger.error(

--- a/distmqtt/client.py
+++ b/distmqtt/client.py
@@ -246,7 +246,7 @@ class MQTTClient:
 
         try:
             return await self._do_connect()
-        except ConnectionError as e:
+        except ConnectException as e:
             self.logger.warning("Connection failed: %r", e)
             auto_reconnect = self.config.get("auto_reconnect", False)
             if not auto_reconnect:
@@ -315,7 +315,7 @@ class MQTTClient:
             try:
                 self.logger.debug("Reconnect attempt %d ...", nb_attempt)
                 return await self._do_connect()
-            except ConnectionError as e:
+            except ConnectException as e:
                 self.logger.warning("Reconnection attempt failed: %r", e)
                 if reconnect_retries >= 0 and nb_attempt > reconnect_retries:
                     self.logger.error(
@@ -329,6 +329,9 @@ class MQTTClient:
                 self.logger.debug("Waiting %d second before next attempt", delay)
                 await anyio.sleep(delay)
                 nb_attempt += 1
+            except Exception as e:
+                self.logger.error("Unknown error while reconnecting: %r", e)
+                raise
 
     async def _do_connect(self):
         return_code = await self._connect_coro()


### PR DESCRIPTION
This fixes #10 at least for complete network loss and if the broker is down:

    async def mqtt_lamp_worker(client, loop):
        "coroutine to handle incoming mqtt messages concerning lamps"
  
          logger.info("mqtt lamp worker startup")
          async with client.subscription(CONFIG.mqtt.lamp_topic, QOS_1) as sub:
                  async for message in sub:
                          if not loop.is_running():
                                  break
  
                          packet = message.publish_packet
                          logger.debug("%s => %s" % (packet.variable_header.topic_name, str(packet.payload.data)))
                          pattern = get_pattern_value(packet.payload.data.decode())
                          if pattern is not None:
                                  await set_lamp(client, pattern) # this publishes the new pattern again
                          else:
                                  logger.warn("ignoring unknown pattern")
  
     async def workers():
          "spawn all required threads as anyio task group"
          loop = asyncio.get_event_loop()
  
          async with open_mqttclient(uri=CONFIG.mqtt.host,
                                                                  config={'keep_alive': 30, 'reconnect_retries': -1, 'reconnect_max_interval': 128},
                                                                  ) as client:
  
                  async with anyio.create_task_group() as tg:
                          await tg.spawn(cyclic_switch_handler, client, loop) # another task which also publishes the new pattern
                          await tg.spawn(mqtt_lamp_worker, client, loop)
  
                  # never unless error
                  logger.error("workers end due to error")
